### PR TITLE
Fix for error enqueing Fontawesome

### DIFF
--- a/dist/getting-started/getting-started.php
+++ b/dist/getting-started/getting-started.php
@@ -28,7 +28,7 @@ function atomic_blocks_start_load_admin_scripts() {
 	wp_enqueue_style( 'atomic-blocks-getting-started' );
 
 	// FontAwesome
-	wp_register_style( 'atomic-blocks-fontawesome', plugins_url( '/inc/fontawesome/css/fontawesome-all.css', dirname( __FILE__ ) ), false, '1.0.0' );
+	wp_register_style( 'atomic-blocks-fontawesome', plugins_url( '/assets/fontawesome/css/fontawesome-all.css', dirname( __FILE__ ) ), false, '1.0.0' );
 	wp_enqueue_style( 'atomic-blocks-fontawesome' );
 }
 add_action( 'admin_enqueue_scripts', 'atomic_blocks_start_load_admin_scripts' );


### PR DESCRIPTION
Fix uses correct path /assets (instead of not existing /inc) to enqueue Fontawesome.