### PR TITLE
Add textdomain to translatable strings in block files.

### DIFF
--- a/src/blocks/block-accordion/index.js
+++ b/src/blocks/block-accordion/index.js
@@ -20,7 +20,7 @@ const { __ } = wp.i18n;
 const { Component } = wp.element;
 
 // Register block
-const { 
+const {
 	registerBlockType,
 	createBlock,
 } = wp.blocks;
@@ -89,7 +89,7 @@ class ABAccordionBlock extends Component {
 			<Accordion { ...this.props }>
 				<RichText
 					tagName="p"
-					placeholder={ __( 'Accordion Title' ) }
+					placeholder={ __( 'Accordion Title', 'atomic-blocks' ) }
 					value={ accordionTitle }
 					className="ab-accordion-title"
 					onChange={ ( value ) => this.props.setAttributes( { accordionTitle: value } ) }
@@ -105,14 +105,14 @@ class ABAccordionBlock extends Component {
 
 // Register the block
 registerBlockType( 'atomic-blocks/ab-accordion', {
-	title: __( 'AB Accordion' ),
-	description: __( 'Add accordion block with a title and text.' ),
+	title: __( 'AB Accordion', 'atomic-blocks' ),
+	description: __( 'Add accordion block with a title and text.', 'atomic-blocks' ),
 	icon: 'editor-ul',
 	category: 'atomic-blocks',
 	keywords: [
-		__( 'accordion' ),
-		__( 'list' ),
-		__( 'atomic' ),
+		__( 'accordion', 'atomic-blocks' ),
+		__( 'list', 'atomic-blocks' ),
+		__( 'atomic', 'atomic-blocks' ),
 	],
 	attributes: blockAttributes,
 
@@ -130,7 +130,7 @@ registerBlockType( 'atomic-blocks/ab-accordion', {
 			<Accordion { ...props }>
 				<details open={accordionOpen}>
 					<summary class="ab-accordion-title">
-						<RichText.Content 
+						<RichText.Content
 							value={ accordionTitle }
 						/>
 					</summary>
@@ -169,13 +169,13 @@ registerBlockType( 'atomic-blocks/ab-accordion', {
 				<Accordion { ...props }>
 					<details open={ props.attributes.accordionOpen }>
 						<summary class="ab-accordion-title">
-							<RichText.Content 
+							<RichText.Content
 								value={ props.attributes.accordionTitle }
 							/>
 						</summary>
-						<RichText.Content 
+						<RichText.Content
 							class="ab-accordion-text"
-							tagName="p" 
+							tagName="p"
 							value={ props.attributes.accordionText }
 						/>
 					</details>

--- a/src/blocks/block-author-profile/index.js
+++ b/src/blocks/block-author-profile/index.js
@@ -115,12 +115,12 @@ const blockAttributes = {
 };
 
 class ABAuthorProfileBlock extends Component {
-	
+
 	render() {
 
 		// Setup the attributes
-		const { 
-			attributes: { 
+		const {
+			attributes: {
 				profileName,
 				profileTitle,
 				profileContent,
@@ -141,7 +141,7 @@ class ABAuthorProfileBlock extends Component {
 				email,
 				website,
 				profileAvatarShape
-			}, 
+			},
 			attributes,
 			isSelected,
 			editable,
@@ -205,7 +205,7 @@ class ABAuthorProfileBlock extends Component {
 				>
 					<RichText
 						tagName="h2"
-						placeholder={ __( 'Add name' ) }
+						placeholder={ __( 'Add name', 'atomic-blocks' ) }
 						keepPlaceholderOnFocus
 						value={ profileName }
 						className='ab-profile-name'
@@ -217,7 +217,7 @@ class ABAuthorProfileBlock extends Component {
 
 					<RichText
 						tagName="p"
-						placeholder={ __( 'Add title' ) }
+						placeholder={ __( 'Add title', 'atomic-blocks' ) }
 						keepPlaceholderOnFocus
 						value={ profileTitle }
 						className='ab-profile-title'
@@ -231,7 +231,7 @@ class ABAuthorProfileBlock extends Component {
 						tagName="div"
 						className='ab-profile-text'
 						multiline="p"
-						placeholder={ __( 'Add profile text...' ) }
+						placeholder={ __( 'Add profile text...', 'atomic-blocks' ) }
 						keepPlaceholderOnFocus
 						value={ profileContent }
 						formattingControls={ [ 'bold', 'italic', 'strikethrough', 'link' ] }
@@ -247,14 +247,14 @@ class ABAuthorProfileBlock extends Component {
 
 // Register the block
 registerBlockType( 'atomic-blocks/ab-profile-box', {
-	title: __( 'AB Profile Box' ),
-	description: __( 'Add a profile box with bio info and social media links.' ),
+	title: __( 'AB Profile Box', 'atomic-blocks' ),
+	description: __( 'Add a profile box with bio info and social media links.', 'atomic-blocks' ),
 	icon: 'admin-users',
 	category: 'atomic-blocks',
 	keywords: [
-		__( 'author' ),
-		__( 'profile' ),
-		__( 'atomic' ),
+		__( 'author', 'atomic-blocks' ),
+		__( 'profile', 'atomic-blocks' ),
+		__( 'atomic', 'atomic-blocks' ),
 	],
 	// Setup the block attributes
 	attributes: blockAttributes,
@@ -290,8 +290,8 @@ registerBlockType( 'atomic-blocks/ab-profile-box', {
 					) }
 				>
 					{ profileName && !! profileName.length && (
-						<RichText.Content 
-							tagName="h2" 
+						<RichText.Content
+							tagName="h2"
 							className="ab-profile-name"
 							style={ {
 								color: profileTextColor
@@ -299,10 +299,10 @@ registerBlockType( 'atomic-blocks/ab-profile-box', {
 							value={ profileName }
 						/>
 					) }
-					
+
 					{ profileTitle && !! profileTitle.length && (
-						<RichText.Content 
-							tagName="p" 
+						<RichText.Content
+							tagName="p"
 							className="ab-profile-title"
 							style={ {
 								color: profileTextColor
@@ -312,8 +312,8 @@ registerBlockType( 'atomic-blocks/ab-profile-box', {
 					) }
 
 					{ profileContent && !! profileContent.length && (
-						<RichText.Content 
-							tagName="div" 
+						<RichText.Content
+							tagName="div"
 							className="ab-profile-text"
 							value={ profileContent }
 						/>

--- a/src/blocks/block-button/index.js
+++ b/src/blocks/block-button/index.js
@@ -18,7 +18,7 @@ const { __ } = wp.i18n;
 // Extend component
 const { Component } = wp.element;
 
-// Register block 
+// Register block
 const { registerBlockType } = wp.blocks;
 
 // Register editor components
@@ -39,7 +39,7 @@ const {
 } = wp.components;
 
 class ABButtonBlock extends Component {
-	
+
 	render() {
 
 		// Setup the attributes
@@ -63,7 +63,7 @@ class ABButtonBlock extends Component {
 			<CustomButton { ...this.props }>
 				<RichText
 					tagName="span"
-					placeholder={ __( 'Button text...' ) }
+					placeholder={ __( 'Button text...', 'atomic-blocks' ) }
 					keepPlaceholderOnFocus
 					value={ buttonText }
 					formattingControls={ [] }
@@ -96,7 +96,7 @@ class ABButtonBlock extends Component {
 					/>
 					<IconButton
 						icon="editor-break"
-						label={ __( 'Apply' ) }
+						label={ __( 'Apply', 'atomic-blocks' ) }
 						type="submit"
 					/>
 				</form>
@@ -107,14 +107,14 @@ class ABButtonBlock extends Component {
 
 // Register the block
 registerBlockType( 'atomic-blocks/ab-button', {
-	title: __( 'AB Button' ),
-	description: __( 'Add a customizable button.' ),
+	title: __( 'AB Button', 'atomic-blocks' ),
+	description: __( 'Add a customizable button.', 'atomic-blocks' ),
 	icon: 'admin-links',
 	category: 'atomic-blocks',
 	keywords: [
-		__( 'button' ),
-		__( 'link' ),
-		__( 'atomic' ),
+		__( 'button', 'atomic-blocks' ),
+		__( 'link', 'atomic-blocks' ),
+		__( 'atomic', 'atomic-blocks' ),
 	],
 	attributes: {
 		buttonText: {
@@ -156,18 +156,18 @@ registerBlockType( 'atomic-blocks/ab-button', {
 
 	// Save the attributes and markup
 	save: function( props ) {
-		
+
 		// Setup the attributes
 		const { buttonText, buttonUrl, buttonAlignment, buttonBackgroundColor, buttonTextColor, buttonSize, buttonShape, buttonTarget } = props.attributes;
-		
+
 		// Save the block markup for the front end
 		return (
-			<CustomButton { ...props }>			
+			<CustomButton { ...props }>
 				{	// Check if there is button text and output
 					buttonText && (
 					<a
 						href={ buttonUrl }
-						target={ buttonTarget ? '_blank' : '_self' } 
+						target={ buttonTarget ? '_blank' : '_self' }
 						className={ classnames(
 							'ab-button',
 							buttonShape,
@@ -178,11 +178,11 @@ registerBlockType( 'atomic-blocks/ab-button', {
 							backgroundColor: buttonBackgroundColor,
 						} }
 					>
-						<RichText.Content 
-							value={ buttonText } 
+						<RichText.Content
+							value={ buttonText }
 						/>
 					</a>
-				) }	
+				) }
 			</CustomButton>
 		);
 	},

--- a/src/blocks/block-container/index.js
+++ b/src/blocks/block-container/index.js
@@ -17,7 +17,7 @@ const { __ } = wp.i18n;
 // Extend component
 const { Component } = wp.element;
 
-// Register block 
+// Register block
 const { registerBlockType } = wp.blocks;
 
 // Register editor components
@@ -99,26 +99,26 @@ const blockAttributes = {
 };
 
 class ABContainerBlock extends Component {
-	
+
 	render() {
 
 		// Setup the attributes
-		const { 
-			attributes: { 
+		const {
+			attributes: {
 				containerPaddingTop,
 				containerPaddingRight,
 				containerPaddingBottom,
 				containerPaddingLeft,
 				containerMarginTop,
 				containerMarginBottom,
-				containerWidth, 
+				containerWidth,
 				containerMaxWidth,
-				containerBackgroundColor, 
+				containerBackgroundColor,
 				containerImgURL,
 				containerImgID,
 				containerImgAlt,
 				containerDimRatio,
-			}, 
+			},
 			attributes,
 			isSelected,
 			editable,
@@ -152,7 +152,7 @@ class ABContainerBlock extends Component {
 				<div class="ab-container-inside">
 					{ containerImgURL && !! containerImgURL.length && (
 						<div class="ab-container-image-wrap">
-							<img 
+							<img
 								className={ classnames(
 									'ab-container-image',
 									dimRatioToClass( containerDimRatio ),
@@ -165,8 +165,8 @@ class ABContainerBlock extends Component {
 							/>
 						</div>
 					) }
-				
-					<div 
+
+					<div
 						class="ab-container-content"
 						style={ {
 							maxWidth: `${containerMaxWidth}px`,
@@ -175,21 +175,21 @@ class ABContainerBlock extends Component {
 						<InnerBlocks />
 					</div>
 				</div>
-			</Container>	
+			</Container>
 		];
 	}
 }
 
 // Register the block
 registerBlockType( 'atomic-blocks/ab-container', {
-	title: __( 'AB Container' ),
-	description: __( 'Add a container block to wrap several blocks in a parent container.' ),
+	title: __( 'AB Container', 'atomic-blocks' ),
+	description: __( 'Add a container block to wrap several blocks in a parent container.', 'atomic-blocks' ),
 	icon: 'editor-table',
 	category: 'atomic-blocks',
 	keywords: [
-		__( 'container' ),
-		__( 'section' ),
-		__( 'atomic' ),
+		__( 'container', 'atomic-blocks' ),
+		__( 'section', 'atomic-blocks' ),
+		__( 'atomic', 'atomic-blocks' ),
 	],
 
 	attributes: blockAttributes,
@@ -205,31 +205,31 @@ registerBlockType( 'atomic-blocks/ab-container', {
 
 	// Save the attributes and markup
 	save: function( props ) {
-		
+
 		// Setup the attributes
-		const { 
+		const {
 			containerPaddingTop,
 			containerPaddingRight,
 			containerPaddingBottom,
 			containerPaddingLeft,
 			containerMarginTop,
 			containerMarginBottom,
-			containerWidth, 
+			containerWidth,
 			containerMaxWidth,
-			containerBackgroundColor, 
+			containerBackgroundColor,
 			containerImgURL,
 			containerImgID,
 			containerImgAlt,
 			containerDimRatio,
 		} = props.attributes;
-		
+
 		// Save the block markup for the front end
 		return (
 			<Container { ...props }>
 				<div class="ab-container-inside">
 					{ containerImgURL && !! containerImgURL.length && (
 						<div class="ab-container-image-wrap">
-							<img 
+							<img
 								className={ classnames(
 									'ab-container-image',
 									dimRatioToClass( containerDimRatio ),
@@ -243,7 +243,7 @@ registerBlockType( 'atomic-blocks/ab-container', {
 						</div>
 					) }
 
-					<div 
+					<div
 						class="ab-container-content"
 						style={ {
 							maxWidth: `${containerMaxWidth}px`,

--- a/src/blocks/block-cta/index.js
+++ b/src/blocks/block-cta/index.js
@@ -17,7 +17,7 @@ const { __ } = wp.i18n;
 // Extend component
 const { Component } = wp.element;
 
-// Register block 
+// Register block
 const { registerBlockType } = wp.blocks;
 
 // Register editor components
@@ -125,32 +125,32 @@ const blockAttributes = {
 };
 
 class ABCTABlock extends Component {
-	
+
 	render() {
 
 		// Setup the attributes
-		const { 
-			attributes: { 
-			buttonText, 
-			buttonUrl, 
-			buttonAlignment, 
-			buttonBackgroundColor, 
-			buttonTextColor, 
-			buttonSize, 
-			buttonShape, 
-			buttonTarget, 
-			ctaTitle, 
-			ctaText, 
-			ctaTitleFontSize, 
-			ctaTextFontSize, 
-			ctaWidth, 
-			ctaBackgroundColor, 
+		const {
+			attributes: {
+			buttonText,
+			buttonUrl,
+			buttonAlignment,
+			buttonBackgroundColor,
+			buttonTextColor,
+			buttonSize,
+			buttonShape,
+			buttonTarget,
+			ctaTitle,
+			ctaText,
+			ctaTitleFontSize,
+			ctaTextFontSize,
+			ctaWidth,
+			ctaBackgroundColor,
 			ctaTextColor,
 			imgURL,
 			imgID,
 			imgAlt,
 			dimRatio,
-			}, 
+			},
 			attributes,
 			isSelected,
 			editable,
@@ -189,7 +189,7 @@ class ABCTABlock extends Component {
 			<CallToAction { ...this.props }>
 				{ imgURL && !! imgURL.length && (
 					<div class="ab-cta-image-wrap">
-						<img 
+						<img
 							className={ classnames(
 								'ab-cta-image',
 								dimRatioToClass( dimRatio ),
@@ -206,7 +206,7 @@ class ABCTABlock extends Component {
 				<div class="ab-cta-content">
 					<RichText
 						tagName="h2"
-						placeholder={ __( 'Call-To-Action Title' ) }
+						placeholder={ __( 'Call-To-Action Title', 'atomic-blocks' ) }
 						keepPlaceholderOnFocus
 						value={ ctaTitle }
 						className={ classnames(
@@ -221,7 +221,7 @@ class ABCTABlock extends Component {
 					<RichText
 						tagName="div"
 						multiline="p"
-						placeholder={ __( 'Call To Action Text' ) }
+						placeholder={ __( 'Call To Action Text', 'atomic-blocks' ) }
 						keepPlaceholderOnFocus
 						value={ ctaText }
 						className={ classnames(
@@ -237,7 +237,7 @@ class ABCTABlock extends Component {
 				<div class="ab-cta-button">
 					<RichText
 						tagName="span"
-						placeholder={ __( 'Button text...' ) }
+						placeholder={ __( 'Button text...', 'atomic-blocks' ) }
 						value={ buttonText }
 						formattingControls={ [] }
 						className={ classnames(
@@ -268,7 +268,7 @@ class ABCTABlock extends Component {
 							/>
 							<IconButton
 								icon="editor-break"
-								label={ __( 'Apply' ) }
+								label={ __( 'Apply', 'atomic-blocks' ) }
 								type="submit"
 							/>
 						</form>
@@ -281,14 +281,14 @@ class ABCTABlock extends Component {
 
 // Register the block
 registerBlockType( 'atomic-blocks/ab-cta', {
-	title: __( 'AB Call To Action' ),
-	description: __( 'Add a call to action section with a title, text, and a button.' ),
+	title: __( 'AB Call To Action', 'atomic-blocks' ),
+	description: __( 'Add a call to action section with a title, text, and a button.', 'atomic-blocks' ),
 	icon: 'megaphone',
 	category: 'atomic-blocks',
 	keywords: [
-		__( 'call to action' ),
-		__( 'cta' ),
-		__( 'atomic' ),
+		__( 'call to action', 'atomic-blocks' ),
+		__( 'cta', 'atomic-blocks' ),
+		__( 'atomic', 'atomic-blocks' ),
 	],
 
 	attributes: blockAttributes,
@@ -304,36 +304,36 @@ registerBlockType( 'atomic-blocks/ab-cta', {
 
 	// Save the attributes and markup
 	save: function( props ) {
-		
+
 		// Setup the attributes
-		const { 
-			buttonText, 
-			buttonUrl, 
-			buttonAlignment, 
-			buttonBackgroundColor, 
-			buttonTextColor, 
-			buttonSize, 
-			buttonShape, 
-			buttonTarget, 
-			ctaTitle, 
-			ctaText, 
-			ctaTitleFontSize, 
-			ctaTextFontSize, 
-			ctaWidth, 
-			ctaBackgroundColor, 
+		const {
+			buttonText,
+			buttonUrl,
+			buttonAlignment,
+			buttonBackgroundColor,
+			buttonTextColor,
+			buttonSize,
+			buttonShape,
+			buttonTarget,
+			ctaTitle,
+			ctaText,
+			ctaTitleFontSize,
+			ctaTextFontSize,
+			ctaWidth,
+			ctaBackgroundColor,
 			ctaTextColor,
 			imgURL,
 			imgID,
 			imgAlt,
 			dimRatio,
 		} = props.attributes;
-		
+
 		// Save the block markup for the front end
 		return (
 			<CallToAction { ...props }>
 				{ imgURL && !! imgURL.length && (
 					<div class="ab-cta-image-wrap">
-						<img 
+						<img
 							className={ classnames(
 								'ab-cta-image',
 								dimRatioToClass( dimRatio ),
@@ -349,8 +349,8 @@ registerBlockType( 'atomic-blocks/ab-cta', {
 
 				<div class="ab-cta-content">
 					{ ctaTitle && !! ctaTitle.length && (
-						<RichText.Content 
-							tagName="h2" 
+						<RichText.Content
+							tagName="h2"
 							className={ classnames(
 								'ab-cta-title',
 								'ab-font-size-' + ctaTitleFontSize,
@@ -358,12 +358,12 @@ registerBlockType( 'atomic-blocks/ab-cta', {
 							style={ {
 								color: ctaTextColor,
 							} }
-							value={ ctaTitle } 
+							value={ ctaTitle }
 						/>
 					) }
 					{ ctaText && !! ctaText.length && (
-						<RichText.Content 
-							tagName="div" 
+						<RichText.Content
+							tagName="div"
 							className={ classnames(
 								'ab-cta-text',
 								'ab-font-size-' + ctaTextFontSize,
@@ -371,7 +371,7 @@ registerBlockType( 'atomic-blocks/ab-cta', {
 							style={ {
 								color: ctaTextColor,
 							} }
-							value={ ctaText } 
+							value={ ctaText }
 						/>
 					) }
 				</div>
@@ -379,7 +379,7 @@ registerBlockType( 'atomic-blocks/ab-cta', {
 					<div class="ab-cta-button">
 						<a
 							href={ buttonUrl }
-							target={ buttonTarget ? '_blank' : '_self' } 
+							target={ buttonTarget ? '_blank' : '_self' }
 							className={ classnames(
 								'ab-button',
 								buttonShape,
@@ -390,8 +390,8 @@ registerBlockType( 'atomic-blocks/ab-cta', {
 								backgroundColor: buttonBackgroundColor,
 							} }
 						>
-							<RichText.Content 
-								value={ buttonText } 
+							<RichText.Content
+								value={ buttonText }
 							/>
 						</a>
 					</div>

--- a/src/blocks/block-drop-cap/index.js
+++ b/src/blocks/block-drop-cap/index.js
@@ -37,7 +37,7 @@ const {
 } = wp.components;
 
 class ABDropCapBlock extends Component {
-	
+
 	render() {
 
 		// Setup the attributes
@@ -60,7 +60,7 @@ class ABDropCapBlock extends Component {
 				<RichText
 					tagName="div"
 					multiline="p"
-					placeholder={ __( 'Add paragraph text...' ) }
+					placeholder={ __( 'Add paragraph text...', 'atomic-blocks' ) }
 					keepPlaceholderOnFocus
 					value={ dropCapContent }
 					formattingControls={ [ 'bold', 'italic', 'strikethrough', 'link' ] }
@@ -77,14 +77,14 @@ class ABDropCapBlock extends Component {
 
 // Register the block
 registerBlockType( 'atomic-blocks/ab-drop-cap', {
-	title: __( 'AB Drop Cap' ),
-	description: __( 'Add a styled drop cap to the beginning of your paragraph.' ),
+	title: __( 'AB Drop Cap', 'atomic-blocks' ),
+	description: __( 'Add a styled drop cap to the beginning of your paragraph.', 'atomic-blocks' ),
 	icon: 'format-quote',
 	category: 'atomic-blocks',
 	keywords: [
-		__( 'drop cap' ),
-		__( 'quote' ),
-		__( 'atomic' ),
+		__( 'drop cap', 'atomic-blocks' ),
+		__( 'quote', 'atomic-blocks' ),
+		__( 'atomic', 'atomic-blocks' ),
 	],
 	attributes: {
 		dropCapContent: {
@@ -126,12 +126,12 @@ registerBlockType( 'atomic-blocks/ab-drop-cap', {
 			<DropCap { ...props }>
 				{	// Check if there is text and output
 					dropCapContent && (
-					<RichText.Content 
-						tagName="div" 
+					<RichText.Content
+						tagName="div"
 						className="ab-drop-cap-text"
-						value={ dropCapContent } 
+						value={ dropCapContent }
 					/>
-				) }	
+				) }
 			</DropCap>
 		);
 	},

--- a/src/blocks/block-notice/index.js
+++ b/src/blocks/block-notice/index.js
@@ -42,21 +42,21 @@ const {
 } = wp.components;
 
 class ABNoticeBlock extends Component {
-	
+
 	render() {
 
 		// Setup the attributes
-		const { 
-			attributes: { 
-				noticeTitle, 
-				noticeContent, 
-				noticeAlignment, 
-				noticeBackgroundColor, 
-				noticeTextColor, 
-				noticeTitleColor, 
-				noticeFontSize, 
+		const {
+			attributes: {
+				noticeTitle,
+				noticeContent,
+				noticeAlignment,
+				noticeBackgroundColor,
+				noticeTextColor,
+				noticeTitleColor,
+				noticeFontSize,
 				noticeDismiss
-			}, 
+			},
 			attributes,
 			isSelected,
 			editable,
@@ -92,10 +92,10 @@ class ABNoticeBlock extends Component {
 						{ icons.dismiss }
 					</DismissButton>
 				) }
-				
+
 				<RichText
 					tagName="p"
-					placeholder={ __( 'Notice Title' ) }
+					placeholder={ __( 'Notice Title', 'atomic-blocks' ) }
 					keepPlaceholderOnFocus
 					value={ noticeTitle }
 					className={ classnames(
@@ -110,7 +110,7 @@ class ABNoticeBlock extends Component {
 				<RichText
 					tagName="div"
 					multiline="p"
-					placeholder={ __( 'Add notice text...' ) }
+					placeholder={ __( 'Add notice text...', 'atomic-blocks' ) }
 					value={ noticeContent }
 					className={ classnames(
 						'ab-notice-text'
@@ -127,14 +127,14 @@ class ABNoticeBlock extends Component {
 
 // Register the block
 registerBlockType( 'atomic-blocks/ab-notice', {
-	title: __( 'AB Notice' ),
-	description: __( 'Add a stylized text notice.' ),
+	title: __( 'AB Notice', 'atomic-blocks' ),
+	description: __( 'Add a stylized text notice.', 'atomic-blocks' ),
 	icon: 'format-aside',
 	category: 'atomic-blocks',
 	keywords: [
-		__( 'notice' ),
-		__( 'message' ),
-		__( 'atomic' ),
+		__( 'notice', 'atomic-blocks' ),
+		__( 'message', 'atomic-blocks' ),
+		__( 'atomic', 'atomic-blocks' ),
 	],
 	attributes: {
 		noticeTitle: {
@@ -178,20 +178,20 @@ registerBlockType( 'atomic-blocks/ab-notice', {
 	save: function( props ) {
 
 		// Setup the attributes
-		const { 
-			noticeTitle, 
-			noticeContent, 
-			noticeAlignment, 
-			noticeBackgroundColor, 
-			noticeTextColor, 
-			noticeTitleColor, 
-			noticeFontSize, 
+		const {
+			noticeTitle,
+			noticeContent,
+			noticeAlignment,
+			noticeBackgroundColor,
+			noticeTextColor,
+			noticeTitleColor,
+			noticeFontSize,
 			noticeDismiss
 		} = props.attributes;
-		
+
 		// Save the block markup for the front end
 		return (
-			<NoticeBox { ...props }>			
+			<NoticeBox { ...props }>
 				{ noticeDismiss && (
 					<DismissButton { ...props }>
 						{ icons.dismiss }
@@ -205,21 +205,21 @@ registerBlockType( 'atomic-blocks/ab-notice', {
 							color: noticeTitleColor
 						} }
 					>
-						<RichText.Content 
-							tagName="p" 
-							value={ noticeTitle } 
+						<RichText.Content
+							tagName="p"
+							value={ noticeTitle }
 						/>
 					</div>
 				) }
 
 				{ noticeContent && (
-					<RichText.Content 
-						tagName="div" 
-						class="ab-notice-text" 
+					<RichText.Content
+						tagName="div"
+						class="ab-notice-text"
 						style={ {
 							borderColor: noticeBackgroundColor
 						} }
-						value={ noticeContent } 
+						value={ noticeContent }
 					/>
 				) }
 			</NoticeBox>

--- a/src/blocks/block-post-grid/index.js
+++ b/src/blocks/block-post-grid/index.js
@@ -11,13 +11,13 @@ import './styles/style.scss';
 import './styles/editor.scss';
 
 // Components
-const { __ } = wp.i18n; 
+const { __ } = wp.i18n;
 
 // Extend component
 const { Component } = wp.element;
 
 // Register block controls
-const { 
+const {
 	registerBlockType,
 } = wp.blocks;
 
@@ -28,14 +28,14 @@ export const name = 'core/latest-posts';
 
 // Register the block
 registerBlockType( 'atomic-blocks/ab-post-grid', {
-	title: __( 'AB Post Grid' ),
-	description: __( 'Add a grid or list of customizable posts to your page.' ),
+	title: __( 'AB Post Grid', 'atomic-blocks' ),
+	description: __( 'Add a grid or list of customizable posts to your page.', 'atomic-blocks' ),
 	icon: 'grid-view',
 	category: 'atomic-blocks',
 	keywords: [
-		__( 'post' ),
-		__( 'grid' ),
-		__( 'atomic' ),
+		__( 'post', 'atomic-blocks' ),
+		__( 'grid', 'atomic-blocks' ),
+		__( 'atomic', 'atomic-blocks' ),
 	],
 
 	getEditWrapperProps( attributes ) {

--- a/src/blocks/block-post-grid/index.php
+++ b/src/blocks/block-post-grid/index.php
@@ -24,7 +24,7 @@ function atomic_blocks_render_block_core_latest_posts( $attributes ) {
 		// Get the post ID
 		$post_id = $post->ID;
 
-		// Get the post thumbnail 
+		// Get the post thumbnail
 		$post_thumb_id = get_post_thumbnail_id( $post_id );
 
 		if ( $post_thumb_id && isset( $attributes['displayPostImage'] ) && $attributes['displayPostImage'] ) {
@@ -38,7 +38,7 @@ function atomic_blocks_render_block_core_latest_posts( $attributes ) {
 			'<article class="%1$s">',
 			esc_attr( $post_thumb_class )
 		);
-		
+
 		// Get the featured image
 		if ( isset( $attributes['displayPostImage'] ) && $attributes['displayPostImage'] && $post_thumb_id ) {
 			if( $attributes['imageCrop'] === 'landscape' ) {
@@ -46,11 +46,11 @@ function atomic_blocks_render_block_core_latest_posts( $attributes ) {
 			} else {
 				$post_thumb_size = 'ab-block-post-grid-square';
 			}
-			
-			$list_items_markup .= sprintf( 
+
+			$list_items_markup .= sprintf(
 				'<div class="ab-block-post-grid-image"><a href="%1$s" rel="bookmark">%2$s</a></div>',
 				esc_url( get_permalink( $post_id ) ),
-				wp_get_attachment_image( $post_thumb_id, $post_thumb_size ) 
+				wp_get_attachment_image( $post_thumb_id, $post_thumb_size )
 			);
 		}
 
@@ -59,11 +59,11 @@ function atomic_blocks_render_block_core_latest_posts( $attributes ) {
 			'<div class="ab-block-post-grid-text">'
 		);
 
-			// Get the post title 
+			// Get the post title
 			$title = get_the_title( $post_id );
 
 			if ( ! $title ) {
-				$title = __( 'Untitled' );
+				$title = __( 'Untitled', 'atomic-blocks' );
 			}
 
 			$list_items_markup .= sprintf(
@@ -85,7 +85,7 @@ function atomic_blocks_render_block_core_latest_posts( $attributes ) {
 						esc_html( get_author_posts_url( $post->post_author ) )
 					);
 				}
-				
+
 				// Get the post date
 				if ( isset( $attributes['displayPostDate'] ) && $attributes['displayPostDate'] ) {
 					$list_items_markup .= sprintf(
@@ -148,7 +148,7 @@ function atomic_blocks_render_block_core_latest_posts( $attributes ) {
 	if ( isset( $attributes['className'] ) ) {
 		$class .= ' ' . $attributes['className'];
 	}
-	
+
 	$grid_class = 'ab-post-grid-items';
 
 	if ( isset( $attributes['postLayout'] ) && 'list' === $attributes['postLayout'] ) {
@@ -176,7 +176,7 @@ function atomic_blocks_render_block_core_latest_posts( $attributes ) {
  * Registers the `core/latest-posts` block on server.
  */
 function atomic_blocks_register_block_core_latest_posts() {
-	
+
 	// Check if the register function exists
 	if ( ! function_exists( 'register_block_type' ) ) {
 		return;
@@ -279,7 +279,7 @@ function atomic_blocks_register_rest_fields() {
 			'schema' => null,
 		)
 	);
-	
+
 	// Add author info
 	register_rest_field(
 		'post',
@@ -324,10 +324,10 @@ function atomic_blocks_get_image_src_square( $object, $field_name, $request ) {
 function atomic_blocks_get_author_info( $object, $field_name, $request ) {
 	// Get the author name
 	$author_data['display_name'] = get_the_author_meta( 'display_name', $object['author'] );
-	
+
 	// Get the author link
 	$author_data['author_link'] = get_author_posts_url( $object['author'] );
-	
+
 	// Return the author data
 	return $author_data;
 }

--- a/src/blocks/block-sharing/index.js
+++ b/src/blocks/block-sharing/index.js
@@ -38,19 +38,19 @@ const {
 
 // Register the block
 registerBlockType( 'atomic-blocks/ab-sharing', {
-	title: __( 'AB Sharing' ),
-	description: __( 'Add sharing buttons to your posts and pages.' ),
+	title: __( 'AB Sharing', 'atomic-blocks' ),
+	description: __( 'Add sharing buttons to your posts and pages.', 'atomic-blocks' ),
 	icon: 'admin-links',
 	category: 'atomic-blocks',
 	keywords: [
-		__( 'sharing' ),
-		__( 'social' ),
-		__( 'atomic' ),
+		__( 'sharing', 'atomic-blocks' ),
+		__( 'social', 'atomic-blocks' ),
+		__( 'atomic', 'atomic-blocks' ),
 	],
 
 	// Render the block components
 	edit: props => {
-		
+
 		// Setup the props
 		const {
 			attributes,
@@ -85,7 +85,7 @@ registerBlockType( 'atomic-blocks/ab-sharing', {
 				/>
 			</BlockControls>,
 			// Show the block controls on focus
-			<Inspector 
+			<Inspector
 				{ ...props }
 			/>,
 			// Show the button markup in the editor
@@ -96,7 +96,7 @@ registerBlockType( 'atomic-blocks/ab-sharing', {
 						<a className='ab-share-twitter'>
 							<i class="fab fa-twitter"></i>
 							<span className={ 'ab-social-text' }>
-								{ __( 'Share on Twitter' ) }
+								{ __( 'Share on Twitter', 'atomic-blocks' ) }
 							</span>
 						</a>
 					</li>
@@ -107,7 +107,7 @@ registerBlockType( 'atomic-blocks/ab-sharing', {
 						<a className='ab-share-facebook'>
 							<i class="fab fa-facebook-f"></i>
 							<span className={ 'ab-social-text' }>
-								{ __( 'Share on Facebook' ) }
+								{ __( 'Share on Facebook', 'atomic-blocks' ) }
 							</span>
 						</a>
 					</li>
@@ -118,7 +118,7 @@ registerBlockType( 'atomic-blocks/ab-sharing', {
 						<a className='ab-share-google'>
 							<i class="fab fa-google"></i>
 							<span className={ 'ab-social-text' }>
-								{ __( 'Share on Google' ) }
+								{ __( 'Share on Google', 'atomic-blocks' ) }
 							</span>
 						</a>
 					</li>
@@ -129,7 +129,7 @@ registerBlockType( 'atomic-blocks/ab-sharing', {
 						<a className='ab-share-pinterest'>
 							<i class="fab fa-pinterest-p"></i>
 							<span className={ 'ab-social-text' }>
-								{ __( 'Share on Pinterest' ) }
+								{ __( 'Share on Pinterest', 'atomic-blocks' ) }
 							</span>
 						</a>
 					</li>
@@ -140,7 +140,7 @@ registerBlockType( 'atomic-blocks/ab-sharing', {
 						<a className='ab-share-linkedin'>
 							<i class="fab fa-linkedin"></i>
 							<span className={ 'ab-social-text' }>
-								{ __( 'Share on LinkedIn' ) }
+								{ __( 'Share on LinkedIn', 'atomic-blocks' ) }
 							</span>
 						</a>
 					</li>
@@ -151,7 +151,7 @@ registerBlockType( 'atomic-blocks/ab-sharing', {
 						<a className='ab-share-reddit'>
 							<i class="fab fa-reddit-alien"></i>
 							<span className={ 'ab-social-text' }>
-								{ __( 'Share on reddit' ) }
+								{ __( 'Share on reddit', 'atomic-blocks' ) }
 							</span>
 						</a>
 					</li>
@@ -162,7 +162,7 @@ registerBlockType( 'atomic-blocks/ab-sharing', {
 						<a className='ab-share-email'>
 							<i class="fas fa-envelope"></i>
 							<span className={ 'ab-social-text' }>
-								{ __( 'Share via Email' ) }
+								{ __( 'Share via Email', 'atomic-blocks' ) }
 							</span>
 						</a>
 					</li>

--- a/src/blocks/block-spacer/index.js
+++ b/src/blocks/block-spacer/index.js
@@ -40,7 +40,7 @@ const {
 } = wp.components;
 
 class ABSpacerBlock extends Component {
-	
+
 	render() {
 
 		// Setup the attributes
@@ -87,14 +87,14 @@ class ABSpacerBlock extends Component {
 
 // Register the block
 registerBlockType( 'atomic-blocks/ab-spacer', {
-	title: __( 'AB Spacer' ),
-	description: __( 'Add a spacer and divider between your blocks.' ),
+	title: __( 'AB Spacer', 'atomic-blocks' ),
+	description: __( 'Add a spacer and divider between your blocks.', 'atomic-blocks' ),
 	icon: 'image-flip-vertical',
 	category: 'atomic-blocks',
 	keywords: [
-		__( 'spacer' ),
-		__( 'divider' ),
-		__( 'atomic' ),
+		__( 'spacer', 'atomic-blocks' ),
+		__( 'divider', 'atomic-blocks' ),
+		__( 'atomic', 'atomic-blocks' ),
 	],
 	attributes: {
 		spacerHeight: {
@@ -124,13 +124,13 @@ registerBlockType( 'atomic-blocks/ab-spacer', {
 
 	// Save the attributes and markup
 	save: function( props ) {
-		
+
 		// Setup the attributes
 		const { spacerHeight, spacerDivider, spacerDividerStyle, spacerDividerColor, spacerDividerHeight } = props.attributes;
-		
+
 		// Save the block markup for the front end
 		return (
-			<Spacer { ...props }>			
+			<Spacer { ...props }>
 				<hr style={ { height: spacerHeight ? spacerHeight + 'px' : undefined } }></hr>
 			</Spacer>
 		);

--- a/src/blocks/block-testimonial/index.js
+++ b/src/blocks/block-testimonial/index.js
@@ -13,7 +13,7 @@ import './styles/style.scss';
 import './styles/editor.scss';
 
 // Internationalization
-const { __ } = wp.i18n; 
+const { __ } = wp.i18n;
 
 // Extend component
 const { Component } = wp.element;
@@ -37,23 +37,23 @@ const {
 } = wp.components;
 
 class ABTestimonialBlock extends Component {
-	
+
 	render() {
 
 		// Setup the attributes
-		const { 
-			attributes: { 
-				testimonialName, 
-				testimonialTitle, 
-				testimonialContent, 
-				testimonialAlignment, 
-				testimonialImgURL, 
-				testimonialImgID, 
-				testimonialBackgroundColor, 
-				testimonialTextColor, 
-				testimonialFontSize, 
+		const {
+			attributes: {
+				testimonialName,
+				testimonialTitle,
+				testimonialContent,
+				testimonialAlignment,
+				testimonialImgURL,
+				testimonialImgID,
+				testimonialBackgroundColor,
+				testimonialTextColor,
+				testimonialFontSize,
 				testimonialCiteAlign
-			}, 
+			},
 			attributes,
 			isSelected,
 			editable,
@@ -85,7 +85,7 @@ class ABTestimonialBlock extends Component {
 				<RichText
 					tagName="div"
 					multiline="p"
-					placeholder={ __( 'Add testimonial text...' ) }
+					placeholder={ __( 'Add testimonial text...', 'atomic-blocks' ) }
 					keepPlaceholderOnFocus
 					value={ testimonialContent }
 					formattingControls={ [ 'bold', 'italic', 'strikethrough', 'link' ] }
@@ -105,7 +105,7 @@ class ABTestimonialBlock extends Component {
 								buttonProps={ {
 									className: 'change-image'
 								} }
-								onSelect={ ( img ) => setAttributes( 
+								onSelect={ ( img ) => setAttributes(
 									{
 										testimonialImgID: img.id,
 										testimonialImgURL: img.url,
@@ -124,12 +124,12 @@ class ABTestimonialBlock extends Component {
 								) }
 							>
 							</MediaUpload>
-						</div>	
+						</div>
 					</div>
 
 					<RichText
 						tagName="h2"
-						placeholder={ __( 'Add name' ) }
+						placeholder={ __( 'Add name', 'atomic-blocks' ) }
 						keepPlaceholderOnFocus
 						value={ testimonialName }
 						className='ab-testimonial-name'
@@ -138,10 +138,10 @@ class ABTestimonialBlock extends Component {
 						} }
 						onChange={ ( value ) => this.props.setAttributes( { testimonialName: value } ) }
 					/>
-					
+
 					<RichText
 						tagName="small"
-						placeholder={ __( 'Add title' ) }
+						placeholder={ __( 'Add title', 'atomic-blocks' ) }
 						keepPlaceholderOnFocus
 						value={ testimonialTitle }
 						className='ab-testimonial-title'
@@ -151,24 +151,24 @@ class ABTestimonialBlock extends Component {
 						onChange={ ( value ) => this.props.setAttributes( { testimonialTitle: value } ) }
 					/>
 				</div>
-			</Testimonial>	
+			</Testimonial>
 		];
 	}
 }
 
 // Register the block
 registerBlockType( 'atomic-blocks/ab-testimonial', {
-	title: __( 'AB Testimonial' ),
-	description: __( 'Add a user testimonial with a name and title.' ),
+	title: __( 'AB Testimonial', 'atomic-blocks' ),
+	description: __( 'Add a user testimonial with a name and title.', 'atomic-blocks' ),
 	icon: 'format-quote',
 	category: 'atomic-blocks',
 	keywords: [
-		__( 'testimonial' ),
-		__( 'quote' ),
-		__( 'atomic' ),
+		__( 'testimonial', 'atomic-blocks' ),
+		__( 'quote', 'atomic-blocks' ),
+		__( 'atomic', 'atomic-blocks' ),
 	],
 	attributes: {
-		testimonialName: { 
+		testimonialName: {
 			type: 'array',
 			selector: '.ab-testimonial-name',
 			source: 'children',
@@ -220,31 +220,31 @@ registerBlockType( 'atomic-blocks/ab-testimonial', {
 	save: function( props ) {
 
 		// Setup the attributes
-		const { 
-			testimonialName, 
-			testimonialTitle, 
-			testimonialContent, 
-			testimonialAlignment, 
-			testimonialImgURL, 
-			testimonialImgID, 
-			testimonialBackgroundColor, 
-			testimonialTextColor, 
-			testimonialFontSize, 
+		const {
+			testimonialName,
+			testimonialTitle,
+			testimonialContent,
+			testimonialAlignment,
+			testimonialImgURL,
+			testimonialImgID,
+			testimonialBackgroundColor,
+			testimonialTextColor,
+			testimonialFontSize,
 			testimonialCiteAlign
 		} = props.attributes;
 
 		// Save the block markup for the front end
 		return (
 			<Testimonial { ...props }>
-				<RichText.Content 
-					tagName="div" 
+				<RichText.Content
+					tagName="div"
 					className="ab-testimonial-text"
 					style={ {
 						textAlign: testimonialAlignment,
 					} }
-					value={ testimonialContent } 
+					value={ testimonialContent }
 				/>
-				
+
 				<div class="ab-testimonial-info">
 					{ testimonialImgURL && !! testimonialImgURL.length && (
 						<div class="ab-testimonial-avatar-wrap">
@@ -259,24 +259,24 @@ registerBlockType( 'atomic-blocks/ab-testimonial', {
 					) }
 
 					{ testimonialName && !! testimonialName.length && (
-						<RichText.Content 
-							tagName="h2" 
+						<RichText.Content
+							tagName="h2"
 							className="ab-testimonial-name"
 							style={ {
 								color: testimonialTextColor
 							} }
-							value={ testimonialName } 
+							value={ testimonialName }
 						/>
 					) }
 
 					{ testimonialTitle && !! testimonialTitle.length && (
-						<RichText.Content 
-							tagName="small" 
+						<RichText.Content
+							tagName="small"
 							className="ab-testimonial-title"
 							style={ {
 								color: testimonialTextColor
 							} }
-							value={ testimonialTitle } 
+							value={ testimonialTitle }
 						/>
 					) }
 				</div>


### PR DESCRIPTION
The POT file will need to be regenerated, but I'm not sure if the tools for that scan JS files yet.

Sorry about the large PR. My editor automatically strips unnecessary trailing whitespace for standards compliance.