### PR TITLE
Check for attributes before outputting

### DIFF
--- a/src/blocks/block-sharing/index.php
+++ b/src/blocks/block-sharing/index.php
@@ -95,7 +95,7 @@ add_action( 'wp_footer', 'atomic_blocks_social_icon_footer_script' );
  */
 function atomic_blocks_render_sharing( $attributes ) {
 	global $post;
-	
+
 	// Setup the featured image
 	if ( has_post_thumbnail() ) {
 		$thumbnail_id = get_post_thumbnail_id( $post->ID );
@@ -239,17 +239,23 @@ function atomic_blocks_render_sharing( $attributes ) {
 		);
 	}
 
+	$shareButtonStyle = ( isset( $attributes['shareButtonStyle'] ) ? $attributes['shareButtonStyle'] : null );
+	$shareButtonShape = ( isset( $attributes['shareButtonShape'] ) ? $attributes['shareButtonShape'] : null );
+	$shareButtonSize = ( isset( $attributes['shareButtonSize'] ) ? $attributes['shareButtonSize'] : null );
+	$shareButtonColor = ( isset( $attributes['shareButtonColor'] ) ? $attributes['shareButtonColor'] : null );
+	$shareAlignment = ( isset( $attributes['shareAlignment'] ) ? $attributes['shareAlignment'] : null );
+
 	// Render the list of share links
 	$block_content = sprintf(
 		'<div class="wp-block-atomic-blocks-ab-sharing ab-block-sharing %2$s %3$s %4$s %5$s %6$s">
 			<ul class="ab-share-list">%1$s</ul>
 		</div>',
 		$share_url,
-		$attributes['shareButtonStyle'],
-		$attributes['shareButtonShape'],
-		$attributes['shareButtonSize'],
-		$attributes['shareButtonColor'],
-		$attributes['shareAlignment']
+		$shareButtonStyle,
+		$shareButtonShape,
+		$shareButtonSize,
+		$shareButtonColor,
+		$shareAlignment
 	);
 
 	return $block_content;

--- a/src/blocks/block-sharing/index.php
+++ b/src/blocks/block-sharing/index.php
@@ -239,23 +239,17 @@ function atomic_blocks_render_sharing( $attributes ) {
 		);
 	}
 
-	$shareButtonStyle = ( isset( $attributes['shareButtonStyle'] ) ? $attributes['shareButtonStyle'] : null );
-	$shareButtonShape = ( isset( $attributes['shareButtonShape'] ) ? $attributes['shareButtonShape'] : null );
-	$shareButtonSize = ( isset( $attributes['shareButtonSize'] ) ? $attributes['shareButtonSize'] : null );
-	$shareButtonColor = ( isset( $attributes['shareButtonColor'] ) ? $attributes['shareButtonColor'] : null );
-	$shareAlignment = ( isset( $attributes['shareAlignment'] ) ? $attributes['shareAlignment'] : null );
-
 	// Render the list of share links
 	$block_content = sprintf(
 		'<div class="wp-block-atomic-blocks-ab-sharing ab-block-sharing %2$s %3$s %4$s %5$s %6$s">
 			<ul class="ab-share-list">%1$s</ul>
 		</div>',
 		$share_url,
-		$shareButtonStyle,
-		$shareButtonShape,
-		$shareButtonSize,
-		$shareButtonColor,
-		$shareAlignment
+		isset( $attributes['shareButtonStyle'] ) ? $attributes['shareButtonStyle'] : null,
+		isset( $attributes['shareButtonShape'] ) ? $attributes['shareButtonShape'] : null,
+		isset( $attributes['shareButtonSize'] ) ? $attributes['shareButtonSize'] : null,
+		isset( $attributes['shareButtonColor'] ) ? $attributes['shareButtonColor'] : null,
+		isset( $attributes['shareAlignment'] ) ? $attributes['shareAlignment'] : null
 	);
 
 	return $block_content;


### PR DESCRIPTION
This fix checks for block attributes before outputting the corresponding class on the block.